### PR TITLE
Add pack metadata for resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,9 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew build
+        
+      - name: Upload mod artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mod-jar
+          path: build/libs/*.jar

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 15,
+    "description": "Create: More Package Couriers resources"
+  }
+}


### PR DESCRIPTION
## Summary
- add a pack metadata file so the mod's built-in resources and data are discovered by Forge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d894ae80b48323b7b2ac0411a163d9